### PR TITLE
feat: 초대받은 대시보드 무한 스크롤, 검색, 수락/거절 기능 추가

### DIFF
--- a/.http
+++ b/.http
@@ -1,8 +1,8 @@
 ### 대시보드 초대
-POST https://sp-taskify-api.vercel.app/2-10/dashboards/2930/invitations
+POST https://sp-taskify-api.vercel.app/2-10/dashboards/3516/invitations
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Nzk4LCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA2OTYzNTY5LCJpc3MiOiJzcC10YXNraWZ5In0.4k4gGN7IlhMem3pl93isjoMynL0JoU6tZv9uugBrWQQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OTkzLCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA3NDIyNDE4LCJpc3MiOiJzcC10YXNraWZ5In0.00Dg1L53I943WCXuSNmmJpzMl2-RuPBqGLDThPzZkLo
 
 {
   "email": "test@test.com",
@@ -12,10 +12,10 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Nzk4LCJ0ZWFtS
 POST https://sp-taskify-api.vercel.app/2-10/dashboards
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Nzk4LCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA2OTYzNTY5LCJpc3MiOiJzcC10YXNraWZ5In0.4k4gGN7IlhMem3pl93isjoMynL0JoU6tZv9uugBrWQQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OTkzLCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA3NDIyNDE4LCJpc3MiOiJzcC10YXNraWZ5In0.00Dg1L53I943WCXuSNmmJpzMl2-RuPBqGLDThPzZkLo
 
 {
-  "title": "test5",
+  "title": "h",
   "color": "#7AC555"
 }
 
@@ -23,4 +23,4 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Nzk4LCJ0ZWFtS
 GET https://sp-taskify-api.vercel.app/2-10/dashboards?navigationMethod=infiniteScroll
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Nzk4LCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA2OTYzNTY5LCJpc3MiOiJzcC10YXNraWZ5In0.4k4gGN7IlhMem3pl93isjoMynL0JoU6tZv9uugBrWQQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OTkzLCJ0ZWFtSWQiOiIyLTEwIiwiaWF0IjoxNzA3NDIyNDE4LCJpc3MiOiJzcC10YXNraWZ5In0.00Dg1L53I943WCXuSNmmJpzMl2-RuPBqGLDThPzZkLo

--- a/src/api/fetchInvitation.tsx
+++ b/src/api/fetchInvitation.tsx
@@ -2,8 +2,9 @@ import axios from 'axios';
 import { parse } from 'cookie';
 import { instance } from '@/libs/axios';
 import { INVITATION_URL } from '@/constants/apiUrl';
+import { InvitationData } from '@/types/InvitationType';
 
-export default async function fetchInvitation(cursorId: number) {
+export default async function fetchInvitation(cursorId: number | null): Promise<InvitationData | undefined> {
   const cookies = parse(document.cookie);
   const accessToken = cookies.accessToken;
 
@@ -12,7 +13,7 @@ export default async function fetchInvitation(cursorId: number) {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     const invitationData = response.data;
-    console.log(`beforeLastId=${cursorId}`, invitationData);
+    return invitationData;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       console.log(error);

--- a/src/api/replyInvitation.tsx
+++ b/src/api/replyInvitation.tsx
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { parse } from 'cookie';
+import { instance } from '@/libs/axios';
+import { INVITATION_URL } from '@/constants/apiUrl';
+
+export default async function replyInvitation(invitationId: number, inviteAccepted: boolean) {
+  const cookies = parse(document.cookie);
+  const accessToken = cookies.accessToken;
+
+  try {
+    return await instance.put(
+      INVITATION_URL + `/${invitationId}`,
+      { inviteAccepted },
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.log(error);
+      const errorMessage = error.message;
+      throw new Error(errorMessage);
+    }
+  }
+}

--- a/src/api/searchInvitation.tsx
+++ b/src/api/searchInvitation.tsx
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { parse } from 'cookie';
+import { instance } from '@/libs/axios';
+import { INVITATION_URL } from '@/constants/apiUrl';
+import { InvitationData } from '@/types/InvitationType';
+
+export default async function searchInvitation(title: string): Promise<InvitationData | undefined> {
+  const cookies = parse(document.cookie);
+  const accessToken = cookies.accessToken;
+
+  try {
+    const response = await instance.get(INVITATION_URL + `?title=${title}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const invitationData = response.data;
+    return invitationData;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.log(error);
+      const errorMessage = error.response?.data.message;
+      throw new Error(errorMessage);
+    }
+  }
+}

--- a/src/components/domains/mydashboard/InvitedCard.tsx
+++ b/src/components/domains/mydashboard/InvitedCard.tsx
@@ -1,34 +1,65 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from './TableLayout';
 import CardTitle from '@/components/common/CardTitle';
 import EmptyView from './EmptyView';
 import { SearchInput } from './SearchInput';
 import { Button } from '@/components/ui/button';
-import { InvitationData } from '@/types/InvitationType';
+import { Invitation, InvitationData } from '@/types/InvitationType';
 import fetchInvitation from '@/api/fetchInvitation';
+import replyInvitation from '@/api/replyInvitation';
 
 export default function InvitedCard(initialInvitationData: InvitationData) {
-  const [invitationList, setInvitationList] = useState(initialInvitationData.invitations);
-  const [cursorId, setCursorId] = useState(initialInvitationData.cursorId);
-
-  console.log('cursorId', cursorId, 'invitaions', invitationList);
+  const [invitationList, setInvitationList] = useState<Invitation[] | []>(initialInvitationData.invitations);
+  const [cursorId, setCursorId] = useState<number | null>(initialInvitationData.cursorId);
 
   const lastElementRef = useRef<HTMLTableRowElement>(null);
+
+  const handleIntersect = useCallback(
+    (entries: IntersectionObserverEntry[]): void => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && cursorId !== null) {
+          fetchInvitation(cursorId)
+            .then((res) => {
+              if (res) {
+                // TODO: 하나의 함수에서 set 두개 사용 금지. (but 동작은 잘 되고 log가 이상함)
+                // 리팩토링 필요
+                setInvitationList((prev) => [...prev, ...res.invitations]);
+                setCursorId(res.cursorId);
+                console.log('새로운 cursorId:', cursorId, '추가된 invitations:', invitationList);
+              }
+            })
+            .catch((error) => {
+              console.log(error);
+              throw new Error(error);
+            });
+        }
+      });
+    },
+    [cursorId],
+  );
+
   useEffect(() => {
-    if (lastElementRef.current) {
-      console.log('lastEl', lastElementRef.current.id);
-    }
-  });
+    const observer = new IntersectionObserver(handleIntersect, { threshold: 0.8, root: null });
 
-  // const handleIntersect = (cursorId: number) => {
-  //   fetchInvitation(cursorId);
-  // };
+    lastElementRef.current && observer.observe(lastElementRef.current);
 
-  // const observer = new IntersectionObserver(handleIntersect, { threshold: 0.9, root: null });
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleIntersect, lastElementRef]);
+
+  const handleReplyInvitation = (invitationId: number, inviteAccepted: boolean) => {
+    replyInvitation(invitationId, inviteAccepted).then(() => {
+      setInvitationList((prev) => {
+        return prev.filter((e) => e.id !== invitationId);
+      });
+    });
+  };
 
   return (
     <div className="max-w-[1022px] pt-6 pb-5 px-4 md:pt-8 md:pb-0 md:px-7 rounded-lg bg-white">
       <CardTitle className="mb-6">초대받은 대시보드</CardTitle>
+      {/* TODO: invitationList(화면단)으로 체크하면 렌더링 되지않은 뒤쪽 데이터 체크 불가 */}
       {invitationList.length === 0 ? (
         <EmptyView />
       ) : (
@@ -66,10 +97,21 @@ export default function InvitedCard(initialInvitationData: InvitationData) {
                     </TableCell>
                     <TableCell>
                       <div className="flex justify-between md:justify-start gap-2.5">
-                        <Button variant="violet" size="input" text="input" className="w-full h-8 md:w-[84px] md:h-8">
+                        <Button
+                          variant="violet"
+                          size="input"
+                          text="input"
+                          className="w-full h-8 md:w-[84px] md:h-8"
+                          onClick={() => handleReplyInvitation(invitation.id, true)}
+                        >
                           수락
                         </Button>
-                        <Button size="input" text="input" className="w-full h-8 md:w-[84px] md:h-8">
+                        <Button
+                          size="input"
+                          text="input"
+                          className="w-full h-8 md:w-[84px] md:h-8"
+                          onClick={() => handleReplyInvitation(invitation.id, false)}
+                        >
                           거절
                         </Button>
                       </div>

--- a/src/pages/mydashboard/index.tsx
+++ b/src/pages/mydashboard/index.tsx
@@ -11,6 +11,7 @@ import DashboardHeader from '@/components/header/dashboardHeader';
 import SideBar from '@/components/domains/dashboard/sidebar/SideBar';
 
 export default function MyDashboardPage({ invitationData }: InferGetServerSidePropsType<GetServerSideProps>) {
+  console.log('=== Initial Data ===', 'cursor:', invitationData.cursorId, 'invitations', invitationData.invitations);
   return (
     <div className="flex w-screen bg-gray-FAFAFA">
       <SideBar />

--- a/src/pages/mydashboard/index.tsx
+++ b/src/pages/mydashboard/index.tsx
@@ -11,7 +11,7 @@ import DashboardHeader from '@/components/header/dashboardHeader';
 import SideBar from '@/components/domains/dashboard/sidebar/SideBar';
 
 export default function MyDashboardPage({ invitationData }: InferGetServerSidePropsType<GetServerSideProps>) {
-  console.log('=== Initial Data ===', 'cursor:', invitationData.cursorId, 'invitations', invitationData.invitations);
+  // console.log('=== Initial Data ===', 'invitations', invitationData.invitations, 'cursor:', invitationData.cursorId);
   return (
     <div className="flex w-screen bg-gray-FAFAFA">
       <SideBar />


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 패키지 수정(설치, 삭제, 버전 변경 등)

### 요구 사항
- [x] 초대받은 대시보드는 무한스크롤로 구현합니다
- [x] 초대받은 대시보드가 없으면 “아직 초대받은 대시보드가 없어요”문구를 보여줍니다.
- [x] 초대받은 대시보드에서 이름(title)으로 검색이 가능합니다(키워드가 이름에 일부라도 포함되면 모두 검색됩니다.).
- [x] 초대받은 대시보드에서 '수락' 버튼을 누르면 대시보드가 추가됩니다.
- [x] 초대받은 대시보드에서 '거절' 버튼을 누르면 해당 대시보드는 삭제됩니다.

### 코드 설명(필요할 경우만)


### 변경 사항
- 페이지 진입 시 '초대받은 대시보드 전체 목록'에 대하여 무한 스크롤이 적용됩니다.
- title 검색 시 '검색한 결과에 대한 초대받은 대시보드 목록'이 렌더링 됩니다.
- 이 때, 검색 결과에 관해서는 무한 스크롤이 적용되지 않습니다.(자세한 내용은 노션 기록 참고)
- 각 초대받은 대시보드에 관하여 수락 또는 거절을 할 수 있습니다.

### 테스트 결과
- 로컬 환경에서 정상 동작
